### PR TITLE
add three shortcodes

### DIFF
--- a/layouts/partials/components/nav.html
+++ b/layouts/partials/components/nav.html
@@ -46,7 +46,7 @@
     <div class="nav-section">
       {{ template "header" (dict "title" .Title "url" .RelPermalink "here" $here) }}
 
-      {{ with .RegularPages }}
+      {{ with .RegularPages.ByParam "weight" }}
       {{ template "links" (dict "links" . "here" $here) }}
       {{ end }}
     </div>
@@ -56,7 +56,7 @@
     <div class="nav-section">
       {{ template "header" (dict "title" .Title "url" .RelPermalink "here" $here) }}
 
-      {{ with .RegularPages }}
+      {{ with .RegularPages.ByParam "weight" }}
       {{ template "links" (dict "links" . "here" $here) }}
       {{ end }}
     </div>


### PR DESCRIPTION
Adds 3 shortcodes:

github-button.html [docs](https://github.com/guumaster/hugo-shortcodes/blob/master/github-buttons.md)
asciinema.html [docs](https://github.com/guumaster/hugo-shortcodes/blob/master/asciinema.md)
contributors.html [docs](https://github.com/guumaster/hugo-shortcodes/blob/master/all-contributors.md)

You can see examples [guumaster/hostctl](https://guumaster.github.io/hostctl/) and the docs are here [guumaster/hugo-shortcodes](https://github.com/guumaster/hugo-shortcodes/) you can add the docs to the example site if you want.

Closes #6 