### PR TITLE
urlize tags

### DIFF
--- a/layouts/partials/components/hero.html
+++ b/layouts/partials/components/hero.html
@@ -32,7 +32,7 @@
       <div class="tags">
         {{ range . }}
         {{ $tag := printf "#%s" . }}
-        {{ $url := printf "/tags/%s" . | relLangURL }}
+        {{ $url := printf "/tags/%s" . | urlize | relLangURL }}
         <a class="tag is-primary is-small" href="{{ $url }}">
           {{ $tag }}
         </a>


### PR DESCRIPTION
## Changed

- URL of a tag is urlized
  - If a tag has space in it, the url of this tag should replace the space with dash.
  - If a tag is capitalized, the url of it should be converted to lower case.


